### PR TITLE
Fix blank page on Render: buffer output so redirects survive strict S…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN { \
     echo 'expose_php = Off'; \
     echo 'display_errors = Off'; \
     echo 'log_errors = On'; \
+    echo 'output_buffering = 4096'; \
     echo 'upload_max_filesize = 8M'; \
     echo 'post_max_size = 10M'; \
     } > /usr/local/etc/php/conf.d/educoach.ini

--- a/includes/config.php
+++ b/includes/config.php
@@ -12,6 +12,13 @@ if (defined('EDUCOACH_BOOTSTRAPPED')) {
 }
 define('EDUCOACH_BOOTSTRAPPED', true);
 
+// Start output buffering before anything else. This makes header()/redirects
+// resilient to stray output (e.g. whitespace after ?> in legacy includes) on
+// servers where output_buffering is off — which silently breaks redirects.
+if (ob_get_level() === 0) {
+    ob_start();
+}
+
 define('APP_ROOT', dirname(__DIR__));
 
 /* -------------------------------------------------------------------------
@@ -85,7 +92,8 @@ define('IS_PRODUCTION', APP_ENV === 'production');
 
 error_reporting(E_ALL);
 ini_set('log_errors', '1');
-ini_set('error_log', APP_ROOT . '/logs/php_errors.log');
+// In containers, log to stderr so the platform (Render) captures it; locally, use a file.
+ini_set('error_log', IS_PRODUCTION ? 'php://stderr' : APP_ROOT . '/logs/php_errors.log');
 // Never leak stack traces / warnings to visitors in production.
 ini_set('display_errors', IS_PRODUCTION ? '0' : '1');
 


### PR DESCRIPTION
…APIs

Legacy includes emit trailing whitespace after ?>. Under Apache (output sent immediately) this marked headers as sent, so post-action header('Location') redirects (register, login, logout, ...) silently failed -> blank 200 page. The PHP built-in server is lenient, so this only surfaced in production.

- Start an output buffer at the top of config.php (portable across SAPIs)
- Set output_buffering=4096 in the Docker PHP config (defence in depth)
- Log errors to stderr in production so the platform captures them