### PR TITLE
Fix image uploads on Render: make profile image dir writable by web s…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,9 @@ RUN chmod +x /usr/local/bin/entrypoint.sh
 # Application code
 COPY . /var/www/html
 
-# Writable runtime directories
-RUN mkdir -p /var/www/html/logs /var/www/html/uploads \
-    && chown -R www-data:www-data /var/www/html/logs /var/www/html/uploads
+# Writable runtime directories (logs, generic uploads, and profile images)
+RUN mkdir -p /var/www/html/logs /var/www/html/uploads /var/www/html/assets/images/profiles \
+    && chown -R www-data:www-data /var/www/html/logs /var/www/html/uploads /var/www/html/assets/images/profiles
 
 # Sensible production PHP defaults
 RUN { \


### PR DESCRIPTION
…erver

move_uploaded_file() targets assets/images/profiles, which was owned by root after COPY, so www-data (Apache) couldn't write -> 'Failed to upload image'. chown the directory to www-data alongside logs/ and uploads/.

Note: Render's free tier has no persistent disk, so uploads are ephemeral (lost on redeploy/restart). Fine for a demo; use object storage for durability.