### PR TITLE
Allow login by username or email; make show-password button work

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -65,4 +65,18 @@ document.addEventListener('DOMContentLoaded', function() {
             }
         });
     }
-}); 
+});
+
+// Show/hide password toggle. Any <button data-toggle-password="#selector"> flips
+// the referenced field between password and text, and swaps the eye icon.
+document.addEventListener('click', function (e) {
+    const btn = e.target.closest('[data-toggle-password]');
+    if (!btn) return;
+    const input = document.querySelector(btn.getAttribute('data-toggle-password'));
+    if (!input) return;
+    const reveal = input.type === 'password';
+    input.type = reveal ? 'text' : 'password';
+    const icon = btn.querySelector('i');
+    if (icon) icon.className = reveal ? 'bi bi-eye-slash' : 'bi bi-eye';
+    btn.setAttribute('aria-label', reveal ? 'Hide password' : 'Show password');
+});

--- a/includes/auth_functions.php
+++ b/includes/auth_functions.php
@@ -14,8 +14,9 @@ define('AUTH_FUNCTIONS_INCLUDED', true);
  * @return array|false User data if authentication successful, false otherwise
  */
 function authenticateUser($pdo, $email, $password) {
-    $stmt = $pdo->prepare("SELECT * FROM Users WHERE email = ? AND is_banned = 0");
-    $stmt->execute([$email]);
+    // Accept either an email address or a username as the identifier.
+    $stmt = $pdo->prepare("SELECT * FROM Users WHERE (email = ? OR username = ?) AND is_banned = 0");
+    $stmt->execute([$email, $email]);
     $user = $stmt->fetch();
 
     if ($user && password_verify($password, $user['password_hash'])) {

--- a/pages/login.php
+++ b/pages/login.php
@@ -20,8 +20,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $email = trim($_POST['email'] ?? '');
         $password = $_POST['password'] ?? '';
 
-        if (!isValidEmail($email) || $password === '') {
-            $error = 'Please enter a valid email and password.';
+        if ($email === '' || $password === '') {
+            $error = 'Please enter your email or username and your password.';
         } else {
             $user = authenticateUser($pdo, $email, $password);
 
@@ -80,11 +80,11 @@ include __DIR__ . '/../includes/header.php';
                         <form action="login.php<?= isset($_GET['redirect']) ? '?redirect=' . urlencode($_GET['redirect']) : '' ?>" method="post" novalidate>
                             <?= csrf_field() ?>
                             <div class="mb-3">
-                                <label for="email" class="form-label">Email address</label>
+                                <label for="email" class="form-label">Email or username</label>
                                 <div class="input-group">
-                                    <span class="input-group-text"><i class="bi bi-envelope"></i></span>
-                                    <input type="email" class="form-control" id="email" name="email"
-                                           value="<?= e($email) ?>" autocomplete="email" required>
+                                    <span class="input-group-text"><i class="bi bi-person"></i></span>
+                                    <input type="text" class="form-control" id="email" name="email"
+                                           value="<?= e($email) ?>" autocomplete="username" required>
                                 </div>
                             </div>
                             <div class="mb-2">


### PR DESCRIPTION
- authenticateUser() now matches email OR username (verified against the DB)
- login form relabelled 'Email or username', uses a text input so non-email identifiers aren't blocked by the browser
- add the missing JS handler for data-toggle-password (the eye button was inert)