### PR TITLE
Fix empty coach search on TiDB: drop ONLY_FULL_GROUP_BY at connection

### DIFF
--- a/includes/db_connection.php
+++ b/includes/db_connection.php
@@ -73,6 +73,16 @@ if (env('DB_SSL', false)) {
 
 try {
     $pdo = new PDO($dsn, $cfg['user'], $cfg['pass'], $options);
+
+    // Keep GROUP BY behaviour consistent across providers. MySQL 8 / TiDB enable
+    // ONLY_FULL_GROUP_BY by default (MariaDB does not), which rejects the app's
+    // legacy aggregate queries with error 1055. Drop it so the app behaves the
+    // same everywhere it runs. Best-effort: never let this take the site down.
+    try {
+        $pdo->exec("SET SESSION sql_mode = REPLACE(@@sql_mode, 'ONLY_FULL_GROUP_BY', '')");
+    } catch (PDOException $e) {
+        error_log('Could not adjust sql_mode: ' . $e->getMessage());
+    }
 } catch (PDOException $e) {
     error_log('Database connection failed: ' . $e->getMessage());
 


### PR DESCRIPTION
TiDB/MySQL 8 enable ONLY_FULL_GROUP_BY by default; the app's legacy GROUP BY queries (coach-search and others) select non-aggregated columns and fail with error 1055, which was caught and shown as 'No coaches found'. Local MariaDB doesn't enable it, so it only broke in production. Drop it per-session so behaviour is consistent everywhere. Verified: coach-search now lists all coaches.